### PR TITLE
Update docker-compose.yml (email)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,8 +75,8 @@ services:
       GRAYLOG_TRANSPORT_EMAIL_AUTH_PASSWORD: "xxxxx"
       GRAYLOG_TRANSPORT_EMAIL_USE_TLS: "true"
       GRAYLOG_TRANSPORT_EMAIL_USE_SSL: "false"
-      GRAYLOG_TRANSPORT_FROM_EMAIL: "graylog@example.com"
-      GRAYLOG_TRANSPORT_SUBJECT_PREFIX: "[graylog]"
+      GRAYLOG_TRANSPORT_EMAIL_FROM_EMAIL: "graylog@example.com"
+      GRAYLOG_TRANSPORT_EMAIL_SUBJECT_PREFIX: "[graylog]"
 
     entrypoint: /usr/bin/tini -- wait-for-it opensearch:9200 -- /docker-entrypoint.sh
     volumes:


### PR DESCRIPTION
Fix docker compose env variables for email functionality.

I was trying to send mail alerts from graylog and I found your post [here](https://community.graylog.org/t/email-transport-is-not-enabled-in-server-configuration-file/28441). 
Unfortunately [gsmith](https://community.graylog.org/u/gsmith) in the snippet he pasted he had a mistake in two variables which can cause email alerts to fail.
If someone use the wrong variable names he will get the following error message:

`"Notification has email recipients and is triggered, but email transport  is not configured. No from address specified for email transport."`

The correct configuration can be verified from [here](https://go2docs.graylog.org/current/setting_up_graylog/server.conf.html#Email).